### PR TITLE
Fix CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,13 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          # Docker seems smart enough to not waste space when we over-write image
+          # (instead of pulling layers w/ registry) but it will ugly-up the image list
+          # So prune for that
           script: |
             docker load -i ~/images.tar
+            rm ~/images.tar
             cd /srv/flipmap-backend
             docker-compose down
             docker-compose up -d
+            docker image prune

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          # Docker seems smart enough to not waste space when we over-write image
-          # (instead of pulling layers w/ registry) but it will ugly-up the image list
-          # So prune for that
+          # Prune (may only work on next connection) overwritten images to not run out of space
+          # images.tar should be over-written anyway but we may as well tidy that too
           script: |
             docker load -i ~/images.tar
             rm ~/images.tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,10 @@ jobs:
         run: "docker build --load -f application.dockerfile -t flipmap-backend ."
 
       - name: Archive images
-        run: "docker save flipmap-caddy:latest flipmap-backend:latest -o images.tar"
-
+        run: |
+          docker save flipmap-caddy:latest flipmap-backend:latest -o images.tar
+          chmod 664 images.tar
+          
       - name: Copy to VPS
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
- Proper perms on tarball in runner
- Prune over-written images (might only work on upload after) to not slowly run us out of space again

Example run: https://github.com/Kajmany/flipmap-backend/actions/runs/13694353879/job/38293325033