### PR TITLE
Change /route for release; Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,103 @@
 # What's All This, Then?
-Elaborate API proxy for **FlipMap, the Map App for Flip-phones!**
+
+Elaborate API proxy for [**FlipMap, the Map App for Flip-phones!**](https://anticomputer.club/)
 
 Relies on public external API's via OpenRouteService and Photon (hosted by Komoot).
 
 Prevents us from having to ship those keys to untrustworthy client devices, and provides convenient input/output that simplifies the phone app.
 
-# Requirements and Compiling
-You may or may not need a suitable 'TLS backend' to build the project (TODO: check this), but you *will* need one to run it. Most systems should already have this, but lightweight containers may require explicit installation. Ensure OpenSSL (often `libssl`) and the standard CA certificates for the distribution are installed. **Not having these will result in an early runtime panic upon attempting to construct the `ExternalRequester`.**
+## Requirements and Compiling
+
+You may or may not need a suitable 'TLS backend' to build the project (TODO: check this), but you _will_ need one to run it. Most systems should already have this, but lightweight containers may require explicit installation. Ensure OpenSSL (often `libssl`) and the standard CA certificates for the distribution are installed. **Not having these will result in an early runtime panic upon attempting to construct the `ExternalRequester`.**
 
 Ensure you have a functional Rust toolchain installed. See the [official installation guide](https://www.rust-lang.org/tools/install) for more.
 
 Afterwards, Cargo takes the wheel: `cargo build`.
 
-# Running
+## Running
 
 It is required to set an openrouteservice API key as an environmental variable: `ORS_API_KEY`. Not doing so will cause an early runtime panic, with a slightly more terse message telling you to do this.
 
 Finally, running can be as simple as `<program> 127.0.0.1 1337` for testing on loopback with a very cool port. Use the `--help` flag in the application for up-to-date information on other options. It is possible to do other cool things like point the external API sources to arbitrary addresses.
 
+## Endpoints
 
-# Endpoints
-For now, all API endpoints are placed in `main.rs`. These take and return normal JSON, and not GeoJSON. This is intentional to simplify the app. 
+For now, all API endpoints are placed in `main.rs`. These take and return normal JSON, and not GeoJSON. This is intentional to simplify the app.
 
-## /route
+### /route
+
 HTTP POST
 
-Speaks JSON exclusively
+Requires a starting lat/lon (most likely the users' current position) and a destination position. Returns an array of floats representing flattened coordinates of the form `[lat,lon,lat,lon...]` which are the waypoints forming the road-based route.
 
-Proof of concept route. Poorly named, in hindsight. Requires an 'anchor position' as the lat/lon (most likely the current position), and a query to search for a location to be routed to from that anchor point. Returns an array of floats representing flattened coordinates of the form `[lat,lon,lat,lon...]` which are the waypoints.
+#### Input Dict Items
 
-#### Input Dict Items:
+`src_lat: <number>` Additional Constraint: double-precision float where -90 <= n <= 90
 
-`lat: <number>` Additional Constraint: float where -90 <= n <= 90
+`src_lon: <number>` Additional Constraint: double-precision float where -180 <= n <= 180
 
-`lon: <number>` Additional Constraint: float where -180 <= n <= 180
+`dst_lat: <number>` Additional Constraint: double-precision float where -90 <= n <= 90
 
-`query: <string>`
+`dst_lon: <number>` Additional Constraint: double-precision float where -180 <= n <= 180
 
-#### Output Dict Items:
+#### HTTP 200 Output Dict Items
 
-HTTP 200:
-
-`route: <array[number]>` 
+`route: <array[number]>`
 
 Where route is a flattened LineString of 2-element Positions, representing a contiguous array of waypoints for the route. 'LineString' and 'Position' are used as defined in [RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946).
 
-HTTP 422|500:
+### /get_locations
 
-`msg: <string>` 
+HTTP POST
 
-Where msg is an error that is purposely vague on details for internal matters.
+Queries a list of locations based upon search and starting lat/lon. Length of results may vary.
 
-# Troubleshooting
+#### Input Dict Items
+
+`lat: <number>` Additional Constraint: double-precision float where -90 <= n <= 90
+
+`lon: <number>` Additional Constraint: double-precision float where -180 <= n <= 180
+
+`query: <string>`
+
+`amount: <number>` between 1 and 20
+
+#### HTTP 200 Output Dict Items
+
+`results: <array[lat: number, lon: number, name: string]>`
+
+### Error for ALL Routes
+
+HTTP 500:
+
+`message: <string>`
+
+Where message is an error that is purposely vague. See logs for more details!
+
+HTTP 422:
+
+`message: <string>`
+
+Message is a more precise report of what's wrong with the user-provided input
+
+HTTP 503:
+
+`message: <string>` (body dict)
+
+`RETRY_AFTER: <number>` (header)
+
+Message is probably vague relating to how an external API being overtaxed makes the backend unavailable.
+RETRY_AFTER is taken from the external API or generated by backend's own reckoning. Good faith estimate only.
+
+## Troubleshooting
+
 Tracing is enabled by default, but filters out some detail for brevity. Set the environment variables `RUST_BACKTRACE=1` and `RUST_LOG=trace` to maximize detail.
 
-The error messages returned to the client will purposely not describe the specifics of internal failures. The error messages raised internally also may currently not log enough useful information. See the documentation `cargo doc --bins --document-private-items --open` 
+The error messages returned to the client will purposely not describe the specifics of internal failures. The error messages raised internally also may currently not log enough useful information. See the documentation `cargo doc --bins --document-private-items --open`
 and refer to the `error.rs` enum `RouteError` for the most-up-to-date information on possible errors.
 
-# Deployment Consideration
+## Deployment Consideration
+
 This application expects to be able to make HTTPS requests to API endpoints. Errors will naturally result if firewalls or other configurations get in the way.
 
 TLS for connecting clients, and rate-limiting anywhere are not implemented in the application. **It's strongly recommended to put the application behind a rate-limiting reverse proxy such as NGINX or Caddy.** Future functionality for inbuilt rate-limiting to external APIs is planned, but client-facing rate limiting should be accomplished elsewhere.

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,6 @@ async fn route(
     Ok(ValidatedJson(RouteResponse { route }))
 }
 
-///preet
 #[derive(Deserialize, Debug, Validate)]
 pub struct GetLocationsRequest {
     #[validate(range(min=-90.0, max=90.0))]
@@ -201,6 +200,7 @@ pub struct PlaceResult {
     pub name: String,
 }
 
+/// Used by the app to search out locations from a given position
 #[instrument(level = "debug", skip(client))]
 async fn get_locations(
     State(client): State<Arc<ExternalRequester>>,

--- a/test.sh
+++ b/test.sh
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
+# It's more accurate to think of this as an 'exploration' of the routes.
+
 commands=(
   # Lots of things are handled implicitly by Axum and/or Hyper
   # HTTP 415 Unsupported Media Type
-  'curl -v -m 30 -X POST 127.0.0.1:1337/route -H "Content-Type: text/html; charset=utf-8" -d "woah dude"'
+  'curl -v -m 30 127.0.0.1:1337/route -H "Content-Type: text/html; charset=utf-8" -d "woah dude"'
   # HTTP 405 Method Not Allowed
-  'curl -v -m 30 -X GET 127.0.0.1:1337/route'
+  'curl -v -m 30 127.0.0.1:1337/route'
   # HTTP 404 Not Found
-  'curl -v -m 30 -X GET 127.0.0.1:1337/wp-login.php'
+  'curl -v -m 30 127.0.0.1:1337/wp-login.php'
 
   # Deserialization & Validation errors are handled higher up
-  # HTTP 422 Unprocessable Entity
-  'curl -v -m 30 -X POST 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"lat\": \"Hello, is this the Krusty Krab?\",\"lon\": -123.277961,\"query\":\"Chum Bucket\"}"'
-  # HTTP 422 Unprocessable Entity
-  'curl -v -m 30 -X POST 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"lat\": -4444.568760,\"lon\": -123.277961,\"query\":\"he lat too big\"}"'
-  # HTTP 422 Unprocessable Entity (you get the idea...)
-  'curl -v -m 30 -X POST 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"lon\": -123.277961,\"query\":\"skipped lat day\"}"'
+  # Field has wrong type: HTTP 422 Unprocessable Entity
+  'curl -v -m 30 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"src_lat\": \"Hello, is this the Krusty Krab?\",\"src_lon\": -123.277961,\"dst_lat\": 44.568638, \"dst_lon\": -123.277845}"'
+  # Field fails constraint: HTTP 422 Unprocessable Entity
+  'curl -v -m 30 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"src_lat\": 4444.568760,\"src_lon\": -123.277961,\"dst_lat\": 44.568638, \"dst_lon\": -123.277845}"'
+  # Skipped field: HTTP 422 Unprocessable Entity (you get the idea...)
+  'curl -v -m 30 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"src_lon\": -123.277961,\"dst_lat\": 44.568638, \"dst_lon\": -123.277845}"'
 
   # HTTP 200 Live test. Should work fine.
-  'curl -v -m 30 -X POST 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"lat\": 44.568760,\"lon\": -123.277961,\"query\":\"Downward Dog\"}"'
+  'curl -v -m 30 127.0.0.1:1337/route -H "Content-Type: application/json" -d "{\"src_lat\": 44.568760,\"src_lon\": -123.277961,\"dst_lat\": 44.568638, \"dst_lon\": -123.277845}"'
   # HTTP 200 Live test. Should work fine for search feature.
-  'curl -v -m 30 -X POST 127.0.0.1:8080/get_locations -H "Content-Type: application/json" -d  "{\"amount\": 20, \"lat\": 44.568760,\"lon\": -123.277961,\"query\":\"Starbucks\"}"'
+  'curl -v -m 30 127.0.0.1:1337/get_locations -H "Content-Type: application/json" -d  "{\"amount\": 20, \"lat\": 44.568760,\"lon\": -123.277961,\"query\":\"Starbucks\"}"'
 )
 
 for command in "${commands[@]}"; do


### PR DESCRIPTION
Gives the app control over selecting a location from an initial query string, and just has `/route` take start and end coordinates in a JSON dict. Easy. Docs still need some work but they reflect the routes as they currently are again.